### PR TITLE
fix: resolve dyn skill duplication bug and add train-based skill update

### DIFF
--- a/examples/grpo_trainer/run_alfworld_skills_fixed.sh
+++ b/examples/grpo_trainer/run_alfworld_skills_fixed.sh
@@ -1,0 +1,85 @@
+set -x
+ENGINE=${1:-vllm}
+shift  # Remove first argument so $@ only contains extra params
+export VLLM_ATTENTION_BACKEND=FLASH_ATTN
+
+# Enable more verbose logging
+export RAY_BACKEND_LOG_LEVEL=debug
+export VLLM_LOGGING_LEVEL=DEBUG
+
+# export WANDB_API_KEY=""
+# export MODEL_PATH=""
+export WANDB_NAME="alfworld_grpo_qwen2.5_1.5b_sft_140steps_skills_dynamic"
+
+num_cpus_per_env_worker=0.1 # The CPU resource allocated for each environment worker. If you want to use less CPU resources, you can decrease this value.
+
+train_data_size=16  # Moderate size
+val_data_size=64    # Moderate size
+group_size=8        # Moderate parallelism
+
+# We only use data preparation to indicate the modality and the data size.
+python3 -m examples.data_preprocess.prepare \
+    --mode 'text' \
+    --train_data_size $train_data_size \
+    --val_data_size $val_data_size
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=grpo \
+    data.train_files=$HOME/data/verl-agent/text/train.parquet \
+    data.val_files=$HOME/data/verl-agent/text/test.parquet \
+    data.train_batch_size=$train_data_size \
+    data.val_batch_size=$val_data_size \
+    data.max_prompt_length=4096 \
+    data.max_response_length=512 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    data.return_raw_chat=True \
+    actor_rollout_ref.model.path=$MODEL_PATH \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.ppo_mini_batch_size=128 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=4 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.01 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=8 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.5 \
+    actor_rollout_ref.rollout.enable_chunked_prefill=True \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.rollout.max_num_batched_tokens=8192 \
+    actor_rollout_ref.rollout.max_num_seqs=512 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=0.4 \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=4 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.use_invalid_action_penalty=True \
+    actor_rollout_ref.actor.invalid_action_penalty_coef=0.1 \
+    algorithm.use_kl_in_reward=False \
+    env.env_name=alfworld/AlfredTWEnv \
+    env.seed=0 \
+    env.max_steps=50 \
+    env.rollout.n=$group_size \
+    env.resources_per_worker.num_cpus=$num_cpus_per_env_worker \
+    +env.use_skills_only_memory=True \
+    +env.skills_only_memory.skills_json_path=memory_data/alfworld/claude_style_skills.json \
+    +env.skills_only_memory.top_k=6 \
+    +env.skills_only_memory.enable_dynamic_update=True \
+    +env.skills_only_memory.update_skills_from_train=True \
+    +env.skills_only_memory.update_threshold=0.4 \
+    +env.skills_only_memory.max_new_skills=3 \
+    trainer.critic_warmup=0 \
+    trainer.logger=['console','wandb'] \
+    trainer.project_name='verl_agent_alfworld' \
+    trainer.experiment_name='grpo_qwen2.5_7b_skills_dynamic' \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=1 \
+    trainer.save_freq=10 \
+    trainer.test_freq=5 \
+    trainer.total_epochs=150 \
+    trainer.val_before_train=False $@

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -823,8 +823,9 @@ class RayPPOTrainer:
         for k, v in success_rate.items():
             metric_dict[f'val/{k}'] = v
 
-        # === Skill Bank 动态更新 ===
-        if self.config.env.get('skills_only_memory', {}).get('enable_dynamic_update', False):
+        # === Skill Bank 动态更新（仅当 update_skills_from_train=False 时从 val 更新）===
+        if (self.config.env.get('skills_only_memory', {}).get('enable_dynamic_update', False)
+                and not self.config.env.get('skills_only_memory', {}).get('update_skills_from_train', False)):
             self._update_skills_from_validation(
                 sample_inputs=sample_inputs,
                 sample_outputs=sample_outputs,
@@ -888,10 +889,13 @@ class RayPPOTrainer:
             return
 
         # 分析失败并生成新 skills
+        # FIX: 原先使用 val_envs 的 skills 作为 current_skills，但新 skill
+        # 实际添加到 train envs，导致 val_envs 中永远看不到 dyn_ skills，
+        # _next_dyn_index() 每次都返回 1，重复生成 dyn_001-003 被去重跳过。
         print(f"[SkillUpdate] Analyzing {len(failed_trajectories)} failed trajectories with o3...")
         new_skills = self.skill_updater.analyze_failures(
             failed_trajectories=failed_trajectories,
-            current_skills=retrieval_memory.skills,
+            current_skills=self.envs.retrieval_memory.skills,
         )
 
         if new_skills:
@@ -916,6 +920,74 @@ class RayPPOTrainer:
             print(f"[SkillUpdate] Saved updated skill bank to {save_path}")
         else:
             print("[SkillUpdate] No new skills generated")
+
+    def _update_skills_from_training(self, batch):
+        """
+        根据 training batch 结果更新 skill bank。
+
+        从训练集的失败轨迹中提取新 skill，避免验证集信息泄露到训练过程中。
+        仅在特定任务类型成功率低于阈值时触发更新。
+        """
+        update_config = self.config.env.skills_only_memory
+        threshold = update_config.get('update_threshold', 0.5)
+
+        success_rate = {}
+        for k in batch.non_tensor_batch.keys():
+            if 'success_rate' in k:
+                success_rate[k] = np.mean(batch.non_tensor_batch[k])
+
+        needs_update = False
+        low_success_tasks = []
+        for task_key, rate in success_rate.items():
+            if rate < threshold:
+                needs_update = True
+                task_type = task_key.replace('_success_rate', '')
+                low_success_tasks.append(task_type)
+
+        if not needs_update:
+            print(f"[SkillUpdate-Train] All task success rates above {threshold}, skipping update")
+            return
+
+        print(f"[SkillUpdate-Train] Low success tasks: {low_success_tasks}, triggering skill update...")
+
+        inputs = self.tokenizer.batch_decode(batch.batch["prompts"], skip_special_tokens=True)
+        outputs = self.tokenizer.batch_decode(batch.batch["responses"], skip_special_tokens=True)
+        scores = batch.batch["token_level_scores"].sum(-1).cpu().tolist()
+
+        failed_trajectories = self._collect_failed_trajectories(inputs, outputs, scores)
+
+        if not failed_trajectories:
+            print("[SkillUpdate-Train] No failed trajectories found")
+            return
+
+        if not hasattr(self, 'skill_updater'):
+            from agent_system.memory.skill_updater import SkillUpdater
+            self.skill_updater = SkillUpdater(
+                max_new_skills_per_update=update_config.get('max_new_skills', 3),
+            )
+
+        if not (hasattr(self, 'envs') and hasattr(self.envs, 'retrieval_memory') and self.envs.retrieval_memory):
+            print("[SkillUpdate-Train] No retrieval_memory found in training envs")
+            return
+
+        retrieval_memory = self.envs.retrieval_memory
+
+        print(f"[SkillUpdate-Train] Analyzing {len(failed_trajectories)} failed trajectories...")
+        new_skills = self.skill_updater.analyze_failures(
+            failed_trajectories=failed_trajectories,
+            current_skills=retrieval_memory.skills,
+        )
+
+        if new_skills:
+            retrieval_memory.add_skills(new_skills, category='general')
+            print(f"[SkillUpdate-Train] Added {len(new_skills)} new skills to training envs")
+
+            save_dir = self.config.trainer.get('default_local_dir', './outputs')
+            save_path = os.path.join(save_dir, f'updated_skills_step{self.global_steps}.json')
+            retrieval_memory.save_skills(save_path)
+            print(f"[SkillUpdate-Train] Saved updated skill bank to {save_path}")
+        else:
+            print("[SkillUpdate-Train] No new skills generated")
 
     def _collect_failed_trajectories(
         self,
@@ -1436,6 +1508,13 @@ class RayPPOTrainer:
                             gigpo_enable_similarity= self.config.algorithm.gigpo.enable_similarity,
                             gigpo_similarity_thresh=self.config.algorithm.gigpo.similarity_thresh,
                         )
+
+                    # === Skill Bank 动态更新（从 train batch 提取 skill，防止 val 数据泄露）===
+                    if (self.config.env.get('skills_only_memory', {}).get('enable_dynamic_update', False)
+                            and self.config.env.get('skills_only_memory', {}).get('update_skills_from_train', False)):
+                        skill_update_freq = self.config.env.get('skills_only_memory', {}).get('skill_update_freq', self.config.trainer.get('test_freq', 5))
+                        if self.global_steps % skill_update_freq == 0:
+                            self._update_skills_from_training(batch)
 
                     # update critic
                     if self.use_critic:


### PR DESCRIPTION
1. Fix dyn skill count stuck at 3: _update_skills_from_validation() was reading skills from val_envs but adding to train envs, causing _next_dyn_index() to always start from 1. Changed to use self.envs.retrieval_memory.skills consistently.

2. Add train-based skill update (update_skills_from_train config flag) to avoid validation data leakage.

3. Add run_alfworld_skills_fixed.sh launch script.